### PR TITLE
downgrade the tauri-cli version for github action

### DIFF
--- a/.github/workflows/prerelease-build.yml
+++ b/.github/workflows/prerelease-build.yml
@@ -109,7 +109,8 @@ jobs:
       - name: Install tauri-cli, trunk
         continue-on-error: true
         run: |
-            cargo install tauri-cli trunk
+            cargo install tauri-cli --version 1.5.9
+            cargo install trunk
       
       - name: Verify tauri-cli, trunk installation
         run: |


### PR DESCRIPTION
Just a try to see if the pre-release build would be successful.