### PR TITLE
switch back to the msi bundle for release files on Windows

### DIFF
--- a/.github/workflows/prerelease-build.yml
+++ b/.github/workflows/prerelease-build.yml
@@ -171,4 +171,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}-prerelease
-          path: target\release\bundle\nsis\
+          path: target\release\bundle\msi\


### PR DESCRIPTION
Unnecessary bother to get around Chrome's Malicious File Warning.